### PR TITLE
Drop support for Django 5.0 (EOL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v2.5.0 - UNRELEASED
 
+* Drop support for Django 5.0 (EOL)
+
 ## v2.4.1 - June 25th, 2025
 
 * Add Django version to install requirements.

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     setup_requires=["pytest-runner"],
     options={"bdist_wheel": {"universal": "1"}},
     install_requires=[
-        "Django>=4.2,<6.0",
+        "Django>=4.2,<5.3,!=5.0.*",
         "prometheus-client>=0.7",
     ],
     classifiers=[
@@ -60,7 +60,6 @@ setup(
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
         "Framework :: Django :: 4.2",
-        "Framework :: Django :: 5.0",
         "Framework :: Django :: 5.1",
         "Framework :: Django :: 5.2",
         "Topic :: System :: Monitoring",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 min_version = 4.4
 envlist =
     {py39,py310,py311,py312}-django420-{end2end,unittests}
-    {py310,py311,py312,py313}-django{500,510,520}-{end2end,unittests}
+    {py310,py311,py312,py313}-django{510,520}-{end2end,unittests}
     py39-lint
 
 [gh-actions]
@@ -16,7 +16,6 @@ python =
 [testenv]
 deps =
     django420: Django>=4.2,<4.3
-    django500: Django>=5.0,<5.1
     django510: Django>=5.1,<5.2
     django520: Django>=5.2,<5.3
     coverage


### PR DESCRIPTION
Support for Django 5.0 ended by April 2025

https://upgradedjango.com/5.0/

Depends on:
- https://github.com/django-commons/django-prometheus/pull/476