### PR TITLE
[feat] Adds Django Version as a Metric

### DIFF
--- a/django_prometheus/__init__.py
+++ b/django_prometheus/__init__.py
@@ -6,9 +6,9 @@ https://github.com/korfuri/django-prometheus
 # Import all files that define metrics. This has the effect that
 # `import django_prometheus` will always instantiate all metric
 # objects right away.
-from django_prometheus import middleware, models
+from django_prometheus import middleware, models, info
 
-__all__ = ["middleware", "models", "pip_prometheus"]
+__all__ = ["middleware", "models", "pip_prometheus", "info"]
 
 __version__ = "2.5.0"
 

--- a/django_prometheus/__init__.py
+++ b/django_prometheus/__init__.py
@@ -6,7 +6,7 @@ https://github.com/korfuri/django-prometheus
 # Import all files that define metrics. This has the effect that
 # `import django_prometheus` will always instantiate all metric
 # objects right away.
-from django_prometheus import middleware, models, info
+from django_prometheus import info, middleware, models
 
 __all__ = ["middleware", "models", "pip_prometheus", "info"]
 

--- a/django_prometheus/info.py
+++ b/django_prometheus/info.py
@@ -1,0 +1,8 @@
+from django import get_version
+from prometheus_client import Info
+from django_prometheus.conf import NAMESPACE
+
+django_info = Info("django_info", 
+                   "Django version information", 
+                   namespace=NAMESPACE)
+django_info.info({"version": get_version()})

--- a/django_prometheus/info.py
+++ b/django_prometheus/info.py
@@ -1,11 +1,13 @@
-from django import get_version
+from django import VERSION, get_version
 from prometheus_client import Info
 from django_prometheus.conf import NAMESPACE
 
+major, minor, patch = VERSION[:3]
+version = get_version()
 django_info = Info("django", 
                    "Django version information", 
                    namespace=NAMESPACE)
-django_info.info({"major": get_version().split('.')[0], 
-                  "minor": get_version().split('.')[1], 
-                  "patchlevel": get_version().split('.')[2], 
-                  "version": get_version()})
+django_info.info({"major": str(major), 
+                  "minor": str(minor), 
+                  "patchlevel": str(patch), 
+                  "version": version})

--- a/django_prometheus/info.py
+++ b/django_prometheus/info.py
@@ -2,7 +2,10 @@ from django import get_version
 from prometheus_client import Info
 from django_prometheus.conf import NAMESPACE
 
-django_info = Info("django_version", 
+django_info = Info("django", 
                    "Django version information", 
                    namespace=NAMESPACE)
-django_info.info({"version": get_version()})
+django_info.info({"major": get_version().split('.')[0], 
+                  "minor": get_version().split('.')[1], 
+                  "patchlevel": get_version().split('.')[2], 
+                  "version": get_version()})

--- a/django_prometheus/info.py
+++ b/django_prometheus/info.py
@@ -2,7 +2,7 @@ from django import get_version
 from prometheus_client import Info
 from django_prometheus.conf import NAMESPACE
 
-django_info = Info("django_info", 
+django_info = Info("django_version", 
                    "Django version information", 
                    namespace=NAMESPACE)
 django_info.info({"version": get_version()})

--- a/django_prometheus/tests/test_info.py
+++ b/django_prometheus/tests/test_info.py
@@ -1,7 +1,7 @@
 from django import get_version
+from django_prometheus.info import django_info
 
 def test_info_metric():
-    from django_prometheus.info import django_info
     assert django_info._name == "django"
     assert django_info._documentation == "Django version information"
     assert django_info._value == {"major": get_version().split('.')[0], 

--- a/django_prometheus/tests/test_info.py
+++ b/django_prometheus/tests/test_info.py
@@ -1,0 +1,7 @@
+from django import get_version
+
+def test_info_metric():
+    from django_prometheus.info import django_info
+    assert django_info._name == "django_info"
+    assert django_info._documentation == "Django version information"
+    assert django_info._value == {"version": get_version()}

--- a/django_prometheus/tests/test_info.py
+++ b/django_prometheus/tests/test_info.py
@@ -2,6 +2,9 @@ from django import get_version
 
 def test_info_metric():
     from django_prometheus.info import django_info
-    assert django_info._name == "django_info"
+    assert django_info._name == "django"
     assert django_info._documentation == "Django version information"
-    assert django_info._value == {"version": get_version()}
+    assert django_info._value == {"major": get_version().split('.')[0], 
+                                  "minor": get_version().split('.')[1], 
+                                  "patchlevel": get_version().split('.')[2], 
+                                  "version": get_version()}

--- a/django_prometheus/tests/test_info.py
+++ b/django_prometheus/tests/test_info.py
@@ -1,10 +1,12 @@
-from django import get_version
+from django import VERSION, get_version
 from django_prometheus.info import django_info
 
 def test_info_metric():
+    major, minor, patch = VERSION[:3]
     assert django_info._name == "django"
     assert django_info._documentation == "Django version information"
-    assert django_info._value == {"major": get_version().split('.')[0], 
-                                  "minor": get_version().split('.')[1], 
-                                  "patchlevel": get_version().split('.')[2], 
-                                  "version": get_version()}
+    assert django_info._value == {"major": str(major), 
+                                  "minor": str(minor), 
+                                  "patchlevel": str(patch), 
+                                  "version": get_version(),
+                                  }


### PR DESCRIPTION
- Adds new module (info) for static metrics such as Django Version. New module was justified as to not mix concerns with existing modules that represent dynamic variables.
- Django version includes Major, Minor, and Patch in addition to the full version number.
- Adds unit test for the metric added.
- Imports module at Init.

All unit tests pass and Django Version displays on test Django Project.

Closes #503